### PR TITLE
Migrate to manifest v3

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,12 +12,12 @@
   "chrome_url_overrides": {
     "newtab": "index.html"
   },
-  "browser_action": {
+  "action": {
     "default_popup": "index.html#popup"
   },
   "icons": {
     "48": "small_tiles.png",
     "128": "small_tiles_128.png"
   },
-  "manifest_version": 2
+  "manifest_version": 3
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,6 @@
   "description": "Lightweight New Tab Page with Bookmarks and Top Sites",
   "permissions": [
     "bookmarks",
-    "chrome://favicon/",
     "topSites",
     "management",
     "storage"

--- a/src/infrastructure/favicon.ts
+++ b/src/infrastructure/favicon.ts
@@ -1,3 +1,8 @@
-// TODO: favicon URL is no longer supported in MV3
+// TODO: official favicon API is not yet supported
 // https://github.com/GoogleChrome/developer.chrome.com/issues/1541
-export const faviconBackgroundImage = (url: string) => `url(chrome://favicon/${url})`
+// https://bugs.chromium.org/p/chromium/issues/detail?id=104102
+export const faviconBackgroundImage = (url: string): string | undefined => {
+  if (url.startsWith('https://') || url.startsWith('http://')) {
+    return `url(https://www.google.com/s2/favicons?sz=32&domain_url=${url})`
+  }
+}


### PR DESCRIPTION
See https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/.

## TODO
### Favicon
>Permission 'chrome://favicon/' is unknown or URL pattern is malformed.

It needs to migrate to the new API as https://github.com/GoogleChrome/developer.chrome.com/issues/1541.
