### PR TITLE
Use new favicon API

### DIFF
--- a/cypress/component/App.cy.tsx
+++ b/cypress/component/App.cy.tsx
@@ -17,7 +17,10 @@ describe('<App>', () => {
     cy.viewport('macbook-11')
     cy.mount(<App />)
     cy.get('.Bookmark > a[href="http://www.google.com/"]')
-    cy.wait('@favicon')
+    // https://stackoverflow.com/questions/51246606/test-loading-of-image-in-cypress
+    cy.get<HTMLImageElement>('.BookmarkButton__Icon').should((images) =>
+      images.map((_, image) => expect(image.naturalWidth).to.be.greaterThan(0))
+    )
     cy.screenshot()
   })
 })

--- a/cypress/component/App.cy.tsx
+++ b/cypress/component/App.cy.tsx
@@ -2,13 +2,22 @@ import App from '../../src/App'
 
 describe('<App>', () => {
   it('mounts', () => {
+    // favicon API is not available on Cypress
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/_favicon/',
+      },
+      (req) => {
+        const { pageUrl, size } = req.query
+        req.redirect(`https://www.google.com/s2/favicons?domain_url=${encodeURIComponent(pageUrl)}&sz=${size}`)
+      }
+    ).as('favicon')
+
     cy.viewport('macbook-11')
     cy.mount(<App />)
     cy.get('.Bookmark > a[href="http://www.google.com/"]')
-    cy.get('.BookmarkButton__Icon').and(($img) => {
-      // https://stackoverflow.com/questions/51246606/test-loading-of-image-in-cypress
-      expect($img[0].naturalWidth).to.be.greaterThan(0)
-    })
+    cy.wait('@favicon')
     cy.screenshot()
   })
 })

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
   "permissions": [
     "bookmarks",
     "topSites",
+    "favicon",
     "management",
     "storage"
   ],

--- a/src/infrastructure/favicon.ts
+++ b/src/infrastructure/favicon.ts
@@ -1,8 +1,2 @@
-// TODO: official favicon API is not yet supported
-// https://github.com/GoogleChrome/developer.chrome.com/issues/1541
-// https://bugs.chromium.org/p/chromium/issues/detail?id=104102
-export const faviconImage = (url: string): string | undefined => {
-  if (url.startsWith('https://') || url.startsWith('http://')) {
-    return `https://www.google.com/s2/favicons?sz=32&domain_url=${url}`
-  }
-}
+// https://bugs.chromium.org/p/chromium/issues/detail?id=104102#c63
+export const faviconImage = (url: string) => `/_favicon/?pageUrl=${encodeURIComponent(url)}&size=32`


### PR DESCRIPTION
Chrome MV3 now supports the new favicon API as https://bugs.chromium.org/p/chromium/issues/detail?id=104102#c63.