### PR TITLE
Remove management permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,6 @@
     "bookmarks",
     "topSites",
     "favicon",
-    "management",
     "storage"
   ],
   "chrome_url_overrides": {


### PR DESCRIPTION
I noticed `management` permission is not required now.

It seems it has been added to show Chrome Apps.
https://github.com/int128/bntp/commit/13dac74ed2d96c12b13e3f83e07092fc72b9f761