### PR TITLE
Fix Chrome shortcut does not work if bookmark shortcut is set

### DIFF
--- a/src/ShortcutKey/component.ts
+++ b/src/ShortcutKey/component.ts
@@ -11,8 +11,11 @@ type ShortcutKeyComponentProps = {
 const ShortcutKeyComponent: FC<ShortcutKeyComponentProps> = ({ bookmarkFolders, shortcutMap }) => {
   const bookmarks = bookmarkFolders.flatMap((f) => f.bookmarks)
 
-  useGlobalKey((key: string) => {
-    const shortcutKey = shortcutKeyOf(key)
+  useGlobalKey((e) => {
+    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+      return
+    }
+    const shortcutKey = shortcutKeyOf(e.key)
     if (!shortcutKey) {
       return
     }

--- a/src/ShortcutKey/infrastructure.ts
+++ b/src/ShortcutKey/infrastructure.ts
@@ -1,11 +1,13 @@
 import { useEffect } from 'react'
 
-export const useGlobalKey = (handler: (key: string) => void) =>
+export type GlobalKeyEvent = Pick<KeyboardEvent, 'key' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'metaKey'>
+
+export const useGlobalKey = (handler: (e: GlobalKeyEvent) => void) =>
   useEffect(() => {
     const listener = (e: KeyboardEvent) => {
       // prevent handling a child event such as <input>
       if (e.target === document.body && e.key) {
-        handler(e.key)
+        handler(e)
       }
     }
     window.addEventListener('keydown', listener)

--- a/src/ShortcutKey/infrastructure.ts
+++ b/src/ShortcutKey/infrastructure.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-export type GlobalKeyEvent = Pick<KeyboardEvent, 'key' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'metaKey'>
+export type GlobalKeyEvent = Pick<KeyboardEvent, 'key' | 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>
 
 export const useGlobalKey = (handler: (e: GlobalKeyEvent) => void) =>
   useEffect(() => {


### PR DESCRIPTION
## Problem to solve
I noticed a Chrome shortcut key is not working when a shortcut key is set.

For example,

- Set `B` as a shortcut of bookmark
- Press Command + Shirt + B
- It should not open the bookmark, but opens for now

## How to solve
Don't handle a key if any modifier is set.
