### PR TITLE
Fix popup window size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,10 @@
   color: var(--palette-03);
 }
 
+:root.popup {
+  width: 700px;
+}
+
 body {
   margin: 0;
   font-family: sans-serif;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,12 @@ root.render(
   </React.StrictMode>
 )
 
+// the default size of popup is too small, so explicitly set it
+// https://developer.chrome.com/docs/extensions/reference/action/#popup
+if (document.location.hash === '#popup') {
+  document.documentElement.classList.add('popup')
+}
+
 migratePreferencesFromV2ToV3().catch((e) => console.error(e))
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
## Problem to solve
The popup is too small.

<img width="319" alt="image" src="https://user-images.githubusercontent.com/321266/185737985-ca2aa531-ef2f-48b5-852f-9b6d38348346.png">

## How to solve
Set it explicitly.
>The popup can contain any HTML contents you like, and will be automatically sized to fit its contents. The popup cannot be smaller than 25x25 and cannot be larger than 800x600.
>https://developer.chrome.com/docs/extensions/reference/action/#popup